### PR TITLE
Update gymnasium version to resolve dependency conflict with shimmy

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-gymnasium[atari,accept-rom-license]==0.29.1
+gymnasium[atari,accept-rom-license]>=0.29
 h5py==3.11.0
 huggingface-hub==0.17.2
 hydra-core==1.3


### PR DESCRIPTION
I've updated the requirements.txt while setting up the project with venv on my MacBook. During installation, I encountered the following dependency conflict error related to shimmy[atari] and ale-py:

```bash
INFO: pip is looking at multiple versions of shimmy[atari] to determine which version is compatible with other requirements. This could take a while.
Collecting shimmy[atari]<1.0,>=0.1.0 (from gymnasium[accept-rom-license,atari]==0.29.1->-r requirements.txt (line 1))
  Using cached Shimmy-0.2.0-py3-none-any.whl.metadata (5.2 kB)
  Using cached Shimmy-0.1.0-py3-none-any.whl.metadata (2.1 kB)
ERROR: Cannot install shimmy[atari]==0.1.0, shimmy[atari]==0.2.0 and shimmy[atari]==0.2.1 because these package versions have conflicting dependencies.

The conflict is caused by:
    shimmy[atari] 0.2.1 depends on ale-py~=0.8.1; extra == "atari"
    shimmy[atari] 0.2.0 depends on ale-py~=0.8.0; extra == "atari"
    shimmy[atari] 0.1.0 depends on ale-py~=0.8.0; extra == "atari"

To fix this you could try to:
1. loosen the range of package versions you've specified
2. remove package versions to allow pip to attempt to solve the dependency conflict

ERROR: ResolutionImpossible: for help visit https://pip.pypa.io/en/latest/topics/dependency-resolution/#dealing-with-dependency-conflicts
```